### PR TITLE
Fix install docs description error

### DIFF
--- a/server/docs/docker-install-zh_CN.md
+++ b/server/docs/docker-install-zh_CN.md
@@ -49,7 +49,7 @@ Step4. 启动ServiceDiscovery
 tar xvf service_discovery-*.tar.gz
 cd service_discovery && ./sd
 #如果服务无异常，也可放后台运行  
-#nohup ./sd>/dev/null 2>&1 &
+nohup ./sd>/dev/null 2>&1 &
 ```
 Step5. 启动Manager
 ```
@@ -64,14 +64,14 @@ cd manager
 
 ./manager
 #如果服务无异常，也可放后台运行  
-#nohup ./manager>/dev/null 2>&1 &
+nohup ./manager>/dev/null 2>&1 &
 ```
 Step6. 启动AgentCenter
 ```
 tar xvf agent_center-*.tar.gz
 cd agent_center  && ./agent_center
 #如果服务无异常，也可放后台运行  
-#nohup ./agent_center>/dev/null 2>&1 &
+nohup ./agent_center>/dev/null 2>&1 &
 ```
 ## 开始使用
 安装完成后，可跑测试脚本简单验证连通性

--- a/server/docs/docker-install.md
+++ b/server/docs/docker-install.md
@@ -49,7 +49,7 @@ Step4. Start ServiceDiscovery
 tar xvf service_discovery-*.tar.gz
 cd service_discovery && ./sd
 #If the service is normal, it can be run in the background  
-#nohup ./sd>/dev/null 2>&1 &
+nohup ./sd>/dev/null 2>&1 &
 ```
 Step5. Start Manager
 ```
@@ -64,14 +64,14 @@ cd manager
 
 ./manager
 #If the service is normal, it can be run in the background
-#nohup ./manager>/dev/null 2>&1 &
+nohup ./manager>/dev/null 2>&1 &
 ```
 Step6. Start AgentCenter
 ```
 tar xvf agent_center-*.tar.gz
 cd agent_center  && ./agent_center
 #If the service is normal, it can be run in the background
-#nohup ./agent_center>/dev/null 2>&1 &
+nohup ./agent_center>/dev/null 2>&1 &
 ```
 ## Start using
 You can run a test script to simply verify connectivity

--- a/server/docs/install-zh_CN.md
+++ b/server/docs/install-zh_CN.md
@@ -215,7 +215,7 @@ Auth.Keys: 鉴权秘钥列表，客户端（AC/Manager）需要拿到这个的�
 ```
 ./sd
 #如果服务无异常，也可放后台运行  
-#nohup ./sd>/dev/null 2>&1 &
+nohup ./sd>/dev/null 2>&1 &
 ```
 
 ### 部署 Manager
@@ -244,7 +244,7 @@ Mongodb未加索引会影响系统性能，所以请确保系统必要的字段�
 ```
 ./manager -c conf/svr.yml
 #如果服务无异常，也可放后台运行  
-#nohup ./Manager -c conf/svr.yml>/dev/null 2>&1 &
+nohup ./Manager -c conf/svr.yml>/dev/null 2>&1 &
 ```
 > Manager会在6701端口开放HTTP服务，用于对外API访问和内部通信。
 
@@ -266,7 +266,7 @@ kafka.addrs 是kafka集群的地址列表。
 ```
 ./agent_center -c conf/svr.yml
 #如果服务无异常，也可放后台运行  
-#nohup ./agent_center -c conf/svr.yml>/dev/null 2>&1 &
+nohup ./agent_center -c conf/svr.yml>/dev/null 2>&1 &
 ```
 > AgentCenter会在6751端口开放RPC服务，请保持此端口与所有Agent机器通信畅通。
 AgentCenter会在6752端口开放HTTP服务，请保持此端口与所有Manager机器通信畅通。

--- a/server/docs/install.md
+++ b/server/docs/install.md
@@ -214,7 +214,7 @@ Auth.Keys: List of authentication keys. The client (AgentCenter/Manager) needs t
 ```
 ./sd
 #If the service is normal, it can also run in the background
-#nohup ./sd>/dev/null 2>&1 &
+nohup ./sd>/dev/null 2>&1 &
 ```
 
 ### Deployment Manager
@@ -243,7 +243,7 @@ DB indexes will affect system performance, so please ensure that the necessary f
 ```
 ./manager -c conf/svr.yml
 #If the service is normal, it can also run in the background
-#nohup ./manager -c conf/svr.yml>/dev/null 2>&1 &
+nohup ./manager -c conf/svr.yml>/dev/null 2>&1 &
 ```
 > Manager will open HTTP service on port 6701 for API access and internal communication.
 
@@ -265,7 +265,7 @@ kafka.addrs: the address list of the kafka cluster.
 ```
 ./agent_center -c conf/svr.yml
 #If the service is normal, it can also run in the background
-#nohup ./agent_center -c conf/svr.yml>/dev/null 2>&1 &
+nohup ./agent_center -c conf/svr.yml>/dev/null 2>&1 &
 ```
 > AgentCenter will open RPC service on port 6751. Please keep this port reachable to all Agent machines.
 AgentCenter will open HTTP service on port 6752, please keep this port reachable with all Manager machines.


### PR DESCRIPTION
**Summary**
This PR fix some errors in install docs

### Fixes 
In some installation documents, the # symbol appears before the word nohup, which makes it easy to make mistakes.