### PR TITLE
building issues resolved for kernel 3.16

### DIFF
--- a/driver/LKM/include/anti_rootkit.h
+++ b/driver/LKM/include/anti_rootkit.h
@@ -9,6 +9,7 @@
 #include <linux/version.h>
 #include <linux/kernel.h>
 #include <linux/kallsyms.h>
+#include <asm/syscall.h> /* NR_syscalls */
 
 #define PROC_FILE_HOOK "700"
 #define SYSCALL_HOOK "701"

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -1847,7 +1847,9 @@ int mprotect_pre_handler(struct kprobe *p, struct pt_regs *regs)
                         fput(vma->vm_mm->exe_file);
                     }
                 }
+#ifdef CONFIG_MEMCG
                 target_pid = vma->vm_mm->owner->pid;
+#endif
             }
 
             if (!IS_ERR_OR_NULL(vma->vm_file)) {


### PR DESCRIPTION
1, NR_syscalls not defined, should include <asm/syscall.h>
2, mm->owner only available with memcg enabled