### PR TITLE
fix plugin process is nil

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -128,7 +128,7 @@ func (p *Plugin) Connect(req RegistRequest, conn net.Conn) error {
 	if err != nil {
 		return errors.New("Cann't get req process which pid is " + strconv.FormatUint(uint64(req.Pid), 10))
 	}
-	cmdPgid, err := syscall.Getpgid(p.cmd.Process.Pid)
+	cmdPgid, err := syscall.Getpgid(int(req.Pid))
 	if err != nil {
 		return errors.New("Cann't get cmd process which pid is " + strconv.FormatUint(uint64(p.cmd.Process.Pid), 10))
 	}


### PR DESCRIPTION
插件子进程启动的时候会立刻和插件 server 发送 req
server 收到 req 就立即调用插件的 Connect 方法
但这时候可能插件 cmd 里的 Process 还没构建好，随后引发 panic
所以这里建议改为直接用 req 里的 pid
![Lark20210806-164258](https://user-images.githubusercontent.com/30936981/128483319-bdb936fb-af1e-4c81-a52f-bb8dfab32d61.png)
