### PR TITLE
workaround for ringbuffer backporting: CentOS8 4.18.0-305.10.2.el8_4.…

### DIFF
--- a/driver/LKM/include/trace.h
+++ b/driver/LKM/include/trace.h
@@ -25,6 +25,11 @@
 #define RING_BUFFER_ALL_CPUS -1
 #endif
 
+/* workaround for ringbuffer backporting: CentOS8 4.18.0-305.10.2.el8_4.x86_64 */
+#ifndef ring_buffer
+#define ring_buffer trace_buffer
+#endif
+
 #ifdef SMITH_TRACE_EVENTS
 static inline int __trace_seq_used(struct trace_seq *s)
 {


### PR DESCRIPTION
…x86_64

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] driver support CentOS8 4.18.0-305.10.2.el8_4.x86_64

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
