### PR TITLE
fix socket accept panic

### DIFF
--- a/agent/plugin/server.go
+++ b/agent/plugin/server.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -112,7 +113,10 @@ func Run() {
 	for {
 		conn, err := s.l.Accept()
 		if err != nil {
-			zap.S().Errorf("Accept connect error: %v", err)
+			// Break when socket is closed
+			if errors.Is(err, net.ErrClosed) {
+				break
+			}
 		}
 		go func() {
 			r := msgp.NewReader(conn)


### PR DESCRIPTION
调用 plugin sever Close 方法的时候，触发了 Panic
原因分析：
Golang `net` 包中 `Listener` 中的注释
![1](https://user-images.githubusercontent.com/30936981/128679449-40539a4c-3bd7-4ae9-9bb1-ac2fddad124d.png)
调用 Close 方法后，所有阻塞的 Accept 会返回 Error

当 Listener Close 后，Accept 会不再阻塞，并且不断返回  “use of closed network connection” 错误。
但这里触发异常的主要原因是这时候 conn 对象是 nil ，然而仍旧起了一个 Go 程去解包数据，所以当 io 读取的时候，直接触发了 Panic。

![2](https://user-images.githubusercontent.com/30936981/128680399-3876a8ea-734a-4f70-8e84-83bb902701ba.png)
![3](https://user-images.githubusercontent.com/30936981/128680445-ae7ba57d-9767-49e7-b865-7b115745e855.png)

这里建议用一个外部 flag 标记 socket 关闭，并在 socket Close 前赋值，采用外部 flag 标记可以方便处理资源竞态问题。
在 Accept 后判断标记后直接 break


