### PR TITLE
Add notify path in cron

### DIFF
--- a/agent/collector/main.go
+++ b/agent/collector/main.go
@@ -288,6 +288,7 @@ func main() {
 		defer close(modifyCh)
 		notify.Watch("/etc/cron.d", modifyCh, notify.InModify)
 		notify.Watch("/etc/crontab", modifyCh, notify.InModify)
+		notify.Watch("/var/spool/cron/", modifyCh, notify.InModify)
 		notify.Watch("/var/spool/cron/crontabs/", modifyCh, notify.InModify)
 		defer notify.Stop(modifyCh)
 		for {


### PR DESCRIPTION
Add path "/var/spool/cron/" in cron notify (in centos, according to osquery source code of crontab.cpp)