### PR TITLE
Fix: race upon task->real_parent accessing

### DIFF
--- a/driver/LKM/include/util.h
+++ b/driver/LKM/include/util.h
@@ -44,7 +44,17 @@ extern char *__dentry_path(struct dentry *dentry, char *buf, int buflen);
 
 extern u8 *smith_query_sb_uuid(struct super_block *sb);
 
-#define smith_get_task_struct(tsk) get_task_struct(tsk)
+static struct task_struct *smith_get_task_struct(struct task_struct *tsk)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+	if (tsk && refcount_inc_not_zero(&tsk->usage))
+#else
+	if (tsk && atomic_inc_not_zero(&tsk->usage))
+#endif
+		return tsk;
+    return NULL;
+}
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 39)
 extern void (*__smith_put_task_struct)(struct task_struct *t);
 static inline void smith_put_task_struct(struct task_struct *t)

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -303,8 +303,7 @@ static char *smith_get_pid_tree(int limit)
     const struct cred *current_cred = NULL;
     const struct cred *parent_cred = NULL;
 
-    task = current;
-    smith_get_task_struct(task);
+    task = smith_get_task_struct(current);
 
     snprintf(pid, 24, "%d", task->tgid);
     tmp_data = smith_kzalloc(1024, GFP_ATOMIC);
@@ -330,7 +329,7 @@ static char *smith_get_pid_tree(int limit)
 
         old_task = task;
         rcu_read_lock();
-        task = rcu_dereference(task->real_parent);
+        task = smith_get_task_struct(rcu_dereference(task->real_parent));
         smith_put_task_struct(old_task);
         if (!task || task->pid == 0) {
             rcu_read_unlock();
@@ -346,7 +345,6 @@ static char *smith_get_pid_tree(int limit)
             put_cred(parent_cred);
         }
 
-        smith_get_task_struct(task);
         rcu_read_unlock();
 
         real_data_len = real_data_len + PID_TREE_MATEDATA_LEN;
@@ -385,8 +383,7 @@ void get_process_socket(__be32 * sip4, struct in6_addr *sip6, int *sport,
     struct inet_sock *inet;
     struct socket *socket;
 
-    task = current;
-    smith_get_task_struct(task);
+    task = smith_get_task_struct(current);
 
     while (task && task->pid != 1 && it++ < EXECVE_GET_SOCK_PID_LIMIT) {
         struct files_struct *files;
@@ -490,9 +487,7 @@ next_file:
 next_task:
             old_task = task;
             rcu_read_lock();
-            task = rcu_dereference(task->real_parent);
-            if (task)
-                smith_get_task_struct(task);
+            task = smith_get_task_struct(rcu_dereference(task->real_parent));
             rcu_read_unlock();
             smith_put_task_struct(old_task);
         }


### PR DESCRIPTION
get_process_socket() and smith_get_pid_tree() could grab a task_struct
which is being released, i.e. increment task->usage while it's already
zero-valued. The race window is very small.

The solution is: don't increment task->usage if it's already zero to
avoid the race conditions. Any access of task->real_parent also has
the same risk of races, but not fatal, only gets inconsistent data.

Signed-off-by: shenping.matt <shenping.matt@bytedance.com>

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
