### PR TITLE
codes synced to latest mongoose repo

### DIFF
--- a/driver/LKM/Makefile
+++ b/driver/LKM/Makefile
@@ -9,23 +9,32 @@ MODULE_DIR		:= $(KBUILD_EXTMOD)
 ldflags-y		+= -r -T $(MODULE_DIR)/kprobe.lds
 ccflags-y		+= -I$(MODULE_DIR)/include -I$(MODULE_DIR)
 
-UBUNTU_CHECK := $(shell bash $(MODULE_DIR)/ubuntu_check.sh)
-ifeq ($(UBUNTU_CHECK),DISTRIB_ID=Ubuntu)
-ccflags-y += -D UBUNTU_CHECK
+K_S_PATH	:= /lib/modules/$(KERNEL_HEAD)/source/include
+K_B_PATH	:= /lib/modules/$(KERNEL_HEAD)/build/include
+
+KMOD_CORE_LAYOUT := $(shell bash -c "grep -s module_core\; $(K_S_PATH)/linux/module.h $(K_B_PATH)/linux/module.h")
+ifeq ($(KMOD_CORE_LAYOUT),)
+ccflags-y += -D KMOD_CORE_LAYOUT
 endif
 
-CENTOS_CHECK := $(shell bash $(MODULE_DIR)/centos_check.sh)
-ifeq ($(CENTOS_CHECK),NAME="CentOS Linux")
-ccflags-y += -D CENTOS_CHECK
-else ifeq ($(CENTOS_CHECK),NAME="EulerOS")
-ccflags-y += -D CENTOS_CHECK
+KGID_STRUCT_CHECK	:= $(shell bash -c "grep -s fsgid\; $(K_S_PATH)/linux/cred.h $(K_B_PATH)/linux/cred.h | grep kgid_t")
+ifneq ($(KGID_STRUCT_CHECK),)
+ccflags-y += -D KGID_STRUCT_CHECK
+KGID_CONFIG_CHECK	:= $(shell bash -c "grep -s CONFIG_UIDGID_STRICT_TYPE_CHECKS $(K_S_PATH)/linux/uidgid.h $(K_B_PATH)/linux/uidgid.h")
+ifneq ($(KGID_CONFIG_CHECK),)
+ccflags-y += -D KGID_CONFIG_CHECK
+endif
+endif
+
+IPV6_SUPPORT	:= $(shell bash -c "grep -s skc_v6_daddr\; $(K_S_PATH)/net/sock.h $(K_B_PATH)/net/sock.h")
+ifneq ($(IPV6_SUPPORT),)
+ccflags-y += -D IPV6_SUPPORT
 endif
 
 TRACE_EVENTS_HEADER		:=  /lib/modules/$(KERNEL_HEAD)/build/include/linux/trace_events.h
 TRACE_EVENTS_HEADER_V   := $(TRACE_EVENTS_HEADER)
 TRACE_EVENTS_HEADER_CHECK := $(shell test -e $(TRACE_EVENTS_HEADER_V))
 
-$(warning  $(TRACE_EVENTS_HEADER_CHECK))
 ifeq ($(TRACE_EVENTS_HEADER_CHECK),$(TRACE_EVENTS_HEADER))
 ccflags-y += -D SMITH_TRACE_EVENTS
 endif

--- a/driver/LKM/centos_check.sh
+++ b/driver/LKM/centos_check.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cat /etc/*-release | grep 'NAME="CentOS Linux"'
-cat /etc/*-release | grep 'NAME="EulerOS"'

--- a/driver/LKM/include/kprobe.h
+++ b/driver/LKM/include/kprobe.h
@@ -61,6 +61,21 @@
 #define arg5(pt_regs)	((pt_regs)->regs[5])
 #define arg6(pt_regs)	((pt_regs)->regs[6])
 #define arg7(pt_regs)	((pt_regs)->regs[7])
+#elif defined(CONFIG_ARCH_RV64I)
+#define SC_ARCH_REGS_TO_ARGS(x, ...)	\
+	__KPROBE_MAP(x,__KPROBE_ARGS		\
+		     ,,regs->a0,,regs->a1,,regs->a2	\
+		     ,,regs->a3,,regs->a4,,regs->a5	\
+		     ,,regs->a6,,regs->a7)
+
+#define arg0(pt_regs)	((pt_regs)->a0)
+#define arg1(pt_regs)	((pt_regs)->a1)
+#define arg2(pt_regs)	((pt_regs)->a2)
+#define arg3(pt_regs)	((pt_regs)->a3)
+#define arg4(pt_regs)	((pt_regs)->a4)
+#define arg5(pt_regs)	((pt_regs)->a5)
+#define arg6(pt_regs)	((pt_regs)->a6)
+#define arg7(pt_regs)	((pt_regs)->a7)
 #else
 #error "Unsupported architecture"
 #endif

--- a/driver/LKM/include/struct_wrap.h
+++ b/driver/LKM/include/struct_wrap.h
@@ -60,6 +60,35 @@ static inline unsigned long p_regs_get_arg5(struct pt_regs *p_regs) {
 static inline unsigned long p_regs_get_arg6(struct pt_regs *p_regs) {
    return p_regs->regs[5];
 }
+#elif defined(CONFIG_ARCH_RV64I)
+static inline void smith_regs_set_return_value(struct pt_regs *regs, unsigned long rc)
+{
+	regs->a0 = rc;
+}
+
+static inline unsigned long p_regs_get_arg1(struct pt_regs *p_regs) {
+   return p_regs->a0;
+}
+
+static inline unsigned long p_regs_get_arg2(struct pt_regs *p_regs) {
+   return p_regs->a1;
+}
+
+static inline unsigned long p_regs_get_arg3(struct pt_regs *p_regs) {
+   return p_regs->a2;
+}
+
+static inline unsigned long p_regs_get_arg4(struct pt_regs *p_regs) {
+   return p_regs->a3;
+}
+
+static inline unsigned long p_regs_get_arg5(struct pt_regs *p_regs) {
+   return p_regs->a4;
+}
+
+static inline unsigned long p_regs_get_arg6(struct pt_regs *p_regs) {
+   return p_regs->a5;
+}
 #endif
 
 #ifdef CONFIG_X86
@@ -109,6 +138,30 @@ static inline unsigned long p_regs_get_arg5_syscall(struct pt_regs *p_regs) {
 
 static inline unsigned long p_regs_get_arg6_syscall(struct pt_regs *p_regs) {
    return p_regs->regs[5];
+}
+#elif defined(CONFIG_ARCH_RV64I)
+static inline unsigned long p_regs_get_arg1_syscall(struct pt_regs *p_regs) {
+   return p_regs->a0;
+}
+
+static inline unsigned long p_regs_get_arg2_syscall(struct pt_regs *p_regs) {
+   return p_regs->a1;
+}
+
+static inline unsigned long p_regs_get_arg3_syscall(struct pt_regs *p_regs) {
+   return p_regs->a2;
+}
+
+static inline unsigned long p_regs_get_arg4_syscall(struct pt_regs *p_regs) {
+   return p_regs->a3;
+}
+
+static inline unsigned long p_regs_get_arg5_syscall(struct pt_regs *p_regs) {
+   return p_regs->a4;
+}
+
+static inline unsigned long p_regs_get_arg6_syscall(struct pt_regs *p_regs) {
+   return p_regs->a5;
 }
 #endif
 

--- a/driver/LKM/include/util.h
+++ b/driver/LKM/include/util.h
@@ -16,6 +16,7 @@
 #include <linux/pid_namespace.h>
 #include <linux/ctype.h>
 #include <linux/cred.h>
+#include <linux/kthread.h>
 
 /*
  * constants & globals

--- a/driver/LKM/include/util.h
+++ b/driver/LKM/include/util.h
@@ -66,7 +66,11 @@ static inline void smith_put_task_struct(struct task_struct *t)
 #define smith_put_task_struct(tsk)  put_task_struct(tsk)
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 5, 0)
+#if defined(KGID_STRUCT_CHECK) && (!defined(KGID_CONFIG_CHECK) || \
+    (defined(KGID_CONFIG_CHECK) && defined(CONFIG_UIDGID_STRICT_TYPE_CHECKS)))
+/* vanilla kernels >= 3.5.0, but ubuntu backported for 3.4 */
+# define _XID_VALUE(x)  (x).val
+#else
 # ifndef GLOBAL_ROOT_UID
 # define GLOBAL_ROOT_UID (0)
 # endif
@@ -80,8 +84,6 @@ static inline void smith_put_task_struct(struct task_struct *t)
 # define gid_eq(o, n) ((o) == (n))
 # endif
 # define _XID_VALUE(x)  (x)
-#else
-# define _XID_VALUE(x)  (x).val
 #endif
 
 static __always_inline int check_cred(const struct cred *current_cred, const struct cred *parent_cred)
@@ -125,6 +127,14 @@ static __always_inline void save_cred_info(unsigned int p_cred_info[], const str
     p_cred_info[5] = _XID_VALUE(parent_cred->egid);
     p_cred_info[6] = _XID_VALUE(parent_cred->sgid);
     p_cred_info[7] = _XID_VALUE(parent_cred->fsgid);
+}
+
+static inline int __get_current_uid(void) {
+    return _XID_VALUE(current->real_cred->uid);
+}
+
+static inline int __get_current_euid(void) {
+    return _XID_VALUE(current->real_cred->euid);
 }
 
 /*
@@ -309,23 +319,6 @@ static __always_inline char *smith_get_exe_file(char *buffer, int size)
     (x) = (__typeof__(*(ptr)))__val;                            \
     __ret;                                                      \
 })
-
-
-static inline int __get_current_uid(void) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
-    return current->real_cred->uid.val;
-#else
-    return current->real_cred->uid;
-#endif
-}
-
-static inline int __get_current_euid(void) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
-    return current->real_cred->euid.val;
-#else
-    return current->real_cred->euid;
-#endif
-}
 
 static inline void *__get_dns_query(unsigned char *data, int index, char *res) {
     int i;

--- a/driver/LKM/src/anti_rootkit.c
+++ b/driver/LKM/src/anti_rootkit.c
@@ -56,29 +56,19 @@ static const char *find_hidden_module(unsigned long addr)
         if (!kobj || !kobj->mod)
             continue;
 
-#ifdef UBUNTU_CHECK
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
-		if (BETWEEN_PTR
-		    (addr, kobj->mod->core_layout.base,
-		     kobj->mod->core_layout.size))
+#ifdef KMOD_CORE_LAYOUT
+		/*
+		 * vanilla kernels (kernel.org): >= 4.5.0
+		 * ubuntu kernels: >= 4.4.0
+		 */
+		if (BETWEEN_PTR(addr, kobj->mod->core_layout.base,
+			kobj->mod->core_layout.size))
 			mod_name = kobj->mod->name;
 #else
-		if (BETWEEN_PTR
-		    (addr, kobj->mod->module_core, kobj->mod->core_size))
+		if (BETWEEN_PTR(addr, kobj->mod->module_core,
+			kobj->mod->core_size))
 			mod_name = kobj->mod->name;
 #endif
-#else //UBUNTU_CHECK
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
-        if (BETWEEN_PTR
-		    (addr, kobj->mod->core_layout.base,
-		     kobj->mod->core_layout.size))
-			mod_name = kobj->mod->name;
-#else
-        if (BETWEEN_PTR
-        (addr, kobj->mod->module_core, kobj->mod->core_size))
-            mod_name = kobj->mod->name;
-#endif
-#endif // UBUNTU_CHECK
     }
     spin_unlock(&mod_kset->list_lock);
 

--- a/driver/LKM/src/anti_rootkit.c
+++ b/driver/LKM/src/anti_rootkit.c
@@ -240,7 +240,11 @@ static int anti_rootkit_worker(void *argv)
         }
     } while (!kthread_should_stop());
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+    kthread_complete_and_exit(NULL, 0);
+#else
     do_exit(0);
+#endif
     return 0;
 }
 

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -2209,7 +2209,11 @@ static int smith_dns_work_handler(void *argu)
 #endif
     } while (!kthread_should_stop());
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+    kthread_complete_and_exit(NULL, 0);
+#else
     do_exit(0);
+#endif
     return 0;
 }
 

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -448,7 +448,7 @@ void get_process_socket(__be32 * sip4, struct in6_addr *sip6, int *sport,
                             break;
 #if IS_ENABLED(CONFIG_IPV6)
                             case AF_INET6:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(CENTOS_CHECK)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(IPV6_SUPPORT)
 						    memcpy(dip6, &(sk->sk_v6_daddr), sizeof(sk->sk_v6_daddr));
 						    memcpy(sip6, &(sk->sk_v6_rcv_saddr), sizeof(sk->sk_v6_rcv_saddr));
 						    *sport = ntohs(inet->inet_sport);
@@ -720,7 +720,7 @@ int connect_syscall_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
             case AF_INET6:
 			    sk = socket->sk;
 			    inet = (struct inet_sock *)sk;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(CENTOS_CHECK)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(IPV6_SUPPORT)
 			    if (inet->inet_dport) {
 				    //dip6 = &((struct sockaddr_in6 *)&tmp_dirp)->sin6_addr;
 				    dip6 = &(sk->sk_v6_daddr);
@@ -840,7 +840,7 @@ int connect_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
             break;
 #if IS_ENABLED(CONFIG_IPV6)
         case AF_INET6:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(CENTOS_CHECK)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(IPV6_SUPPORT)
 		    if (inet->inet_dport) {
 			    dip6 = &(sk->sk_v6_daddr);
 			    sip6 = &(sk->sk_v6_rcv_saddr);
@@ -1934,7 +1934,7 @@ int udpv6_recvmsg_entry_handler(struct kretprobe_instance *ri,
 	if (inet->dport == 13568 || inet->dport == 59668)
 #endif
 	{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(CENTOS_CHECK)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) || defined(IPV6_SUPPORT)
 		if (inet->inet_dport) {
 			data->dip6 = &(sk->sk_v6_daddr);
 			data->sip6 = &(sk->sk_v6_rcv_saddr);

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -1012,8 +1012,8 @@ char *smith_query_exe_path(char **alloc, int len, int min)
 
 int execve_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
-    int sa_family = -1;
-    int dport = 0, sport = 0;
+    int sa_family = -1, dport = 0, sport = 0;
+    int rc = regs_return_value(regs);
 
     __be32 dip4;
     __be32 sip4;
@@ -1034,16 +1034,21 @@ int execve_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
     struct in6_addr sip6;
     struct file *file;
     struct execve_data *data;
-    struct tty_struct *tty;
+    struct tty_struct *tty = NULL;
 
+     /* query kretprobe instance for current call */
     data = (struct execve_data *)ri->data;
-    exe_path = smith_query_exe_path(&buffer, PATH_MAX, 128);
+
+    /* ignore the failures that target doesn't exist */
+    if (rc == -ENOENT)
+        goto release_data;
 
     tty = get_current_tty();
     if(tty && strlen(tty->name) > 0)
         tty_name = tty->name;
 
     //exe filter check and argv filter check
+    exe_path = smith_query_exe_path(&buffer, PATH_MAX, 128);
     if (execve_exe_check(exe_path) || execve_argv_check(data->argv))
         goto out;
 
@@ -1082,7 +1087,7 @@ int execve_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
                      dip4, dport, sip4, sport,
                      pid_tree, tty_name, socket_pid,
                      data->ssh_connection, data->ld_preload,
-                     regs_return_value(regs));
+                     rc);
     }
 #if IS_ENABLED(CONFIG_IPV6)
     else if (sa_family == AF_INET6) {
@@ -1092,7 +1097,7 @@ int execve_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
 			      &dip6, dport, &sip6, sport,
 			      pid_tree, tty_name, socket_pid,
 			      data->ssh_connection, data->ld_preload,
-			      regs_return_value(regs));
+			      rc);
 	}
 #endif
     else {
@@ -1101,36 +1106,30 @@ int execve_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
                               tmp_stdin, tmp_stdout,
                               pid_tree, tty_name,
                               data->ssh_connection, data->ld_preload,
-                              regs_return_value(regs));
+                              rc);
     }
 
 out:
     if (pname_buf)
         smith_kfree(pname_buf);
-
     if (stdin_buf)
         smith_kfree(stdin_buf);
-
     if (stdout_buf)
         smith_kfree(stdout_buf);
-
-    if (buffer)
-        smith_kfree(buffer);
-
-    if (data->free_argv)
-        smith_kfree(data->argv);
-
     if (pid_tree)
         smith_kfree(pid_tree);
-
-    if (data->free_ld_preload)
-        smith_kfree(data->ld_preload);
-
-    if (data->free_ssh_connection)
-        smith_kfree(data->ssh_connection);
-
+    if (buffer)
+        smith_kfree(buffer);
     if(tty)
         tty_kref_put(tty);
+
+release_data:
+    if (data->free_argv)
+        smith_kfree(data->argv);
+    if (data->free_ld_preload)
+        smith_kfree(data->ld_preload);
+    if (data->free_ssh_connection)
+        smith_kfree(data->ssh_connection);
 
     return 0;
 }

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -3154,13 +3154,13 @@ void exit_handler(int type)
 
 int exit_pre_handler(struct kprobe *p, struct pt_regs *regs)
 {
-    exit_handler(0);
+    exit_handler(1);
     return 0;
 }
 
 int exit_group_pre_handler(struct kprobe *p, struct pt_regs *regs)
 {
-    exit_handler(1);
+    exit_handler(0);
     return 0;
 }
 

--- a/driver/LKM/src/util.c
+++ b/driver/LKM/src/util.c
@@ -6,6 +6,7 @@
 #include "../include/util.h"
 #include <linux/version.h>
 #include <linux/kallsyms.h>
+#include <linux/prefetch.h>
 
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0) || LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)

--- a/driver/LKM/ubuntu_check.sh
+++ b/driver/LKM/ubuntu_check.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cat /etc/*-release | grep DISTRIB_ID=Ubuntu


### PR DESCRIPTION
Change Logs:
1,  Kernel 5.17 supported: verified with 5.17.0-rc5/5.17.1
2, RISC-V64 supported: verified with VisionFive SBC
3, bugfix in exit_handler:  wrong parameter values
4, ENOENT failures to be ignored for execve events
5, building scripts improved for kernel version handling
