### PR TITLE
Kernel 5.17.x support

### DIFF
--- a/driver/LKM/include/trace.h
+++ b/driver/LKM/include/trace.h
@@ -25,12 +25,6 @@
 #define SZ_32K				0x00008000
 #define SZ_128K				0x00020000
 
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
-#else
-#define PDE_DATA(i)  PDE(i)->data
-#endif
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 static inline int __trace_seq_used(struct trace_seq *s)
 {

--- a/driver/LKM/src/trace.c
+++ b/driver/LKM/src/trace.c
@@ -66,7 +66,14 @@ static int trace_open_pipe(struct inode *inode, struct file *filp)
 
     trace_seq_init(&iter->seq);
     mutex_init(&iter->mutex);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+    iter->ring = pde_data(inode);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
     iter->ring = PDE_DATA(inode);
+#else
+    iter->ring = PDE(inode)->data;
+#endif
     filp->private_data = iter;
     nonseekable_open(inode, filp);
     __module_get(THIS_MODULE);


### PR DESCRIPTION
Building failure due to absence of PDE_DATA:
1) PDE_DATA removed and replaced by pde_data after 5.17
2) only 1 usecase in HIDS: use compiler switch rather macro