### PR TITLE
building issues resolved for latest kernels

### DIFF
--- a/driver/LKM/Makefile
+++ b/driver/LKM/Makefile
@@ -44,6 +44,12 @@ ifeq ($(TRACE_EVENTS_HEADER_CHECK),$(TRACE_EVENTS_HEADER))
 ccflags-y += -D SMITH_TRACE_EVENTS
 endif
 
+PROCFS_H_FILES := $(shell find -L $(K_I_PATH) -path "*/linux/proc_fs.h") /dev/null
+PROCFS_PDE_DATA := $(shell sh -c "grep -s pde_data $(PROCFS_H_FILES)")
+ifneq ($(PROCFS_PDE_DATA),)
+ccflags-y += -D SMITH_PROCFS_PDE_DATA
+endif
+
 else
 
 MODULE_DIR		:= $(shell pwd)

--- a/driver/LKM/src/anti_rootkit.c
+++ b/driver/LKM/src/anti_rootkit.c
@@ -175,7 +175,7 @@ static void analyze_modules(void)
 		}
 
 		kobj = container_of(cur, struct module_kobject, kobj);
-		if (kobj && kobj->mod && kobj->mod->name) {
+		if (kobj && kobj->mod) {
 			if (mod_find_module && !mod_find_module(kobj->mod->name))
 				mod_print(kobj->mod->name);
 		}

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -740,7 +740,7 @@ int connect_syscall_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
 				    dip6 = &(sk->sk_v6_daddr);
 				    sip6 = &(sk->sk_v6_rcv_saddr);
 				    sport = ntohs(inet->inet_sport);
-				    dport = ntohs(((struct sockaddr_in6 *)&tmp_dirp)->sin6_port);
+				    dport = ntohs(((struct sockaddr_in *)&tmp_dirp)->sin_port);
 				    if(dport == 0)
 				        dport = ntohs(inet->inet_dport);
 				    flag = 1;
@@ -751,7 +751,7 @@ int connect_syscall_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
 				    dip6 = &(inet->pinet6->daddr);
 				    sip6 = &(inet->pinet6->saddr);
 				    sport = ntohs(inet->inet_sport);
-				    dport = ntohs(((struct sockaddr_in6 *)&tmp_dirp)->sin6_port);
+				    dport = ntohs(((struct sockaddr_in *)&tmp_dirp)->sin_port);
 				    if(dport)
 				        dport = ntohs(inet->inet_dport);
 				    flag = 1;
@@ -762,7 +762,7 @@ int connect_syscall_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
 				    dip6 = &(inet->pinet6->daddr);
 				    sip6 = &(inet->pinet6->saddr);
 				    sport = ntohs(inet->sport);
-				    dport = ntohs(((struct sockaddr_in6 *)&tmp_dirp)->sin6_port);
+				    dport = ntohs(((struct sockaddr_in *)&tmp_dirp)->sin_port);
 				    if(dport)
 				        dport = ntohs(inet->dport);
 				    flag = 1;

--- a/driver/LKM/src/trace.c
+++ b/driver/LKM/src/trace.c
@@ -67,7 +67,7 @@ static int trace_open_pipe(struct inode *inode, struct file *filp)
     trace_seq_init(&iter->seq);
     mutex_init(&iter->mutex);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || defined(SMITH_PROCFS_PDE_DATA)
     iter->ring = pde_data(inode);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
     iter->ring = PDE_DATA(inode);

--- a/driver/LKM/src/trace.c
+++ b/driver/LKM/src/trace.c
@@ -270,7 +270,8 @@ waitagain:
     if (cnt >= PAGE_SIZE)
         cnt = PAGE_SIZE - 1;
 
-    memset(&iter->seq, 0, sizeof(*iter) - offsetof(struct print_event_iterator, seq));
+    memset((void *)iter + offsetof(struct print_event_iterator, seq), 0,
+           sizeof(*iter) - offsetof(struct print_event_iterator, seq));
 
     mutex_lock(&access_lock);
     while (trace_next_entry_inc(iter) != NULL) {


### PR DESCRIPTION
compiling failure and warnings:
1, PDE_DATA was replaced by pde_data after 5.17rc, and the patch was backported to latest CentOS8 kernels
2, warnings reported by more strict structure boundary check for latest kernels (5.19.x and 6.0rc)
