### PR TITLE
correct header-files for pde_data checking

### DIFF
--- a/driver/LKM/Makefile
+++ b/driver/LKM/Makefile
@@ -44,7 +44,7 @@ ifeq ($(TRACE_EVENTS_HEADER_CHECK),$(TRACE_EVENTS_HEADER))
 ccflags-y += -D SMITH_TRACE_EVENTS
 endif
 
-PROCFS_H_FILES := $(shell find -L $(K_I_PATH) -path "*/linux/proc_fs.h") /dev/null
+PROCFS_H_FILES := $(K_S_PATH)/linux/proc_fs.h $(K_B_PATH)/linux/proc_fs.h $(K_K_PATH)/linux/proc_fs.h
 PROCFS_PDE_DATA := $(shell sh -c "grep -s pde_data $(PROCFS_H_FILES)")
 ifneq ($(PROCFS_PDE_DATA),)
 ccflags-y += -D SMITH_PROCFS_PDE_DATA


### PR DESCRIPTION
header-files corrected for pde_data checking of v1.7

The way of header-files locating via 'find' only works for v1.8.

Signed-off-by: shenping.matt <shenping.matt@bytedance.com>