### PR TITLE
name corrected for kretprobe of compat_sys_execveat

### DIFF
--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -3385,7 +3385,7 @@ struct kretprobe compat_execve_kretprobe = {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)
 struct kretprobe compat_execveat_kretprobe = {
-	    .kp.symbol_name = P_GET_SYSCALL_NAME(execveat),
+	    .kp.symbol_name = P_GET_COMPAT_SYSCALL_NAME(execveat),
 	    .entry_handler = compat_execveat_entry_handler,
 	    .data_size = sizeof(struct execve_data),
 	    .handler = execve_handler,


### PR DESCRIPTION
Should use P_GET_COMPAT_SYSCALL_NAME, not P_GET_SYSCALL_NAME
Related issue: https://github.com/bytedance/Elkeid/issues/266

Signed-off-by: shenping.matt <shenping.matt@bytedance.com>