### PR TITLE
Fix the string trim errors of Container ImageID and ImageName

### DIFF
--- a/plugins/collector/container/container.go
+++ b/plugins/collector/container/container.go
@@ -61,8 +61,8 @@ func (c *criClient) ListContainers(ctx context.Context) ([]Container, error) {
 		container := Container{
 			ID:         criContainer.GetId(),
 			Name:       criContainer.GetMetadata().GetName(),
-			ImageID:    strings.TrimLeft(criContainer.GetImageRef(), "sha256:"),
-			ImageName:  strings.TrimLeft(criContainer.GetImage().GetImage(), "sha256:"),
+			ImageID:    strings.TrimPrefix(criContainer.GetImageRef(), "sha256:"),
+			ImageName:  strings.TrimPrefix(criContainer.GetImage().GetImage(), "sha256:"),
 			State:      StateName[int32(criContainer.GetState())],
 			CreateTime: strconv.FormatInt(criContainer.CreatedAt/1000000000, 10),
 			Runtime:    c.Runtime(),
@@ -84,7 +84,7 @@ func (c *criClient) ListContainers(ctx context.Context) ([]Container, error) {
 				}
 				// real image name
 				if resp.Status.GetImage().GetImage() != "" {
-					container.ImageName = strings.TrimLeft(resp.Status.GetImage().GetImage(), "sha256:")
+					container.ImageName = strings.TrimPrefix(resp.Status.GetImage().GetImage(), "sha256:")
 				}
 			}
 		}
@@ -136,8 +136,8 @@ func (c *dockerClient) ListContainers(ctx context.Context) ([]Container, error) 
 	for _, dockerContainer := range resp {
 		container := Container{
 			ID:         dockerContainer.ID,
-			ImageID:    strings.TrimLeft(dockerContainer.ImageID, "sha256:"),
-			ImageName:  strings.TrimLeft(dockerContainer.Image, "sha256:"),
+			ImageID:    strings.TrimPrefix(dockerContainer.ImageID, "sha256:"),
+			ImageName:  strings.TrimPrefix(dockerContainer.Image, "sha256:"),
 			State:      dockerContainer.State,
 			CreateTime: strconv.FormatInt(dockerContainer.Created, 10),
 			Runtime:    c.Runtime(),


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes the following **bug**:

* [ ] Container ImageID and ImageName will be trimed error if the sha256 value begins with `2`, `5` or `6`.

**Bug detail**

`TrimLeft` returns a slice of the string s with all leading Unicode code points contained in cutset removed.

`TrimPrefix` returns s without the provided leading prefix string. If s doesn't start with prefix, s is returned unchanged.

In conclusion, if the sha256 value begins with `2`, `5` or `6`, Container ImageID and ImageName will be trimed too much not as expected.

```go
package main

import (
	"fmt"
	"strings"
)

func main() {
	fmt.Println(strings.TrimLeft("sha256:620b7f3d1d248633cf84077e6c376dbad6eff5b3510c96fb4550dc896e40e5c4", "sha256:"))
	fmt.Println(strings.TrimPrefix("sha256:620b7f3d1d248633cf84077e6c376dbad6eff5b3510c96fb4550dc896e40e5c4", "sha256:"))
}

// Output:
// 0b7f3d1d248633cf84077e6c376dbad6eff5b3510c96fb4550dc896e40e5c4
// 620b7f3d1d248633cf84077e6c376dbad6eff5b3510c96fb4550dc896e40e5c4
```

**Bug fix**

Replace all `TrimLeft` functions with `TrimPrefix` in container.go.


