### PR TITLE
Possible crash caused by uninitialized structures

### DIFF
--- a/driver/LKM/src/init.c
+++ b/driver/LKM/src/init.c
@@ -81,7 +81,7 @@ module_init(kprobes_init);
 module_exit(kprobes_exit);
 
 MODULE_INFO(homepage, "driver");
-MODULE_VERSION("1.7.0.9");
+MODULE_VERSION("1.7.0.10");
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Will Chen <chenyue.will@bytedance.com>;Ping Shen <shenping.matt@bytedance.com>");

--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -2053,7 +2053,7 @@ int udp_recvmsg_entry_handler(struct kretprobe_instance *ri,
     struct udp_recvmsg_data *data;
 
     data = (struct udp_recvmsg_data *) ri->data;
-    memset(data, sizeof(struct udp_recvmsg_data), 0);
+    memset(data, 0, sizeof(struct udp_recvmsg_data));
 
     flags = (int)p_regs_get_arg6(regs);
     if (flags & MSG_ERRQUEUE)
@@ -2127,7 +2127,7 @@ int udpv6_recvmsg_entry_handler(struct kretprobe_instance *ri,
 	int flags;
 
 	data = (struct udp_recvmsg_data *)ri->data;
-    memset(data, sizeof(struct udp_recvmsg_data), 0);
+    memset(data, 0, sizeof(struct udp_recvmsg_data));
 
 	flags = (int)p_regs_get_arg6(regs);
 	if (flags & MSG_ERRQUEUE)


### PR DESCRIPTION
Wrong parameters were given to memeset, thus leads gcc compiler skipping memset operation (zeroing skipped).

Kernels < 3.2.6 will be affected, CentOS6 are included.