### PR TITLE
enhancement for dns resolving

### DIFF
--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -4820,6 +4820,11 @@ static int __init smith_init(void)
 {
     int ret;
 
+#if defined(MODULE)
+    printk(KERN_INFO "[ELKEID] loading kmod %s (%s).\n",
+           THIS_MODULE->name, THIS_MODULE->version);
+#endif
+
     ret = kernel_symbols_init();
     if (ret)
         return ret;


### PR DESCRIPTION
1) return length checking for udp_recvmsg and udpv6_recvmsg: we only care payloads >= 20 bytes
2) code cleaned for kprobe entry and kretprobe handlers of udp_recvmsg & udpv6_recvmsg