### PR TITLE
add dkms support

### DIFF
--- a/driver/LKM/dkms.conf
+++ b/driver/LKM/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="elkeid-driver"
+PACKAGE_VERSION="1.7.0.10"
+
+BUILT_MODULE_NAME[0]="hids_driver"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/elkeid"
+
+AUTOINSTALL=yes


### PR DESCRIPTION
**Summary**
This PR fixes/implements the following **features**

* [x] Add elkeid-driver dkms support

Example.
As dkms has been installed ,and kernel-headers & gcc version both matches.
```bash
dkms remove $(dkms status|awk -F ', ' '{print $1}'|grep elkeid-driver) --all || true
git clone  https://github.com/bytedance/Elkeid.git
rm -rf /usr/src/elkeid-driver-* || true
cp -r Elkeid/driver/LKM /usr/src/elkeid-driver-1.7.0.10
rm -rf Elkeid
dkms add -m elkeid-driver -v 1.7.0.10
dkms install -m elkeid-driver -v 1.7.0.10
```
Tests
```bash
modinfo hids_driver
modprobe hids_driver
dmesg | tail
rmmod hids_driver
dmesg | tail
```

KnownErrors
* DKMS will failed if gcc or kernel-headers is mismatch from /proc/version
```text
#mismatch example
gcc version == 4.8.0
kernel == 5.14.4
/proc/version == (gcc 8.5.0)
```
