### PR TITLE
cpu-stuck due to multiple registration of nf_hooks

### DIFF
--- a/driver/LKM/src/init.c
+++ b/driver/LKM/src/init.c
@@ -60,7 +60,7 @@ static void __exit kprobes_exit(void)
 module_init(kprobes_init);
 module_exit(kprobes_exit);
 
-MODULE_VERSION("1.7.0.11");
+MODULE_VERSION("1.7.0.12");
 MODULE_LICENSE("GPL");
 
 MODULE_INFO(homepage, "https://github.com/bytedance/Elkeid/tree/main/driver");


### PR DESCRIPTION
nf_register_hooks must be called only once upon nf_hook object, otherwise it would lead dead-loop and thus system hang.

We are using register_pernet_subsys as unified soltuion for all network namespaces, but nf_register_net_hooks is only available kernels >= 4.3.0. nf_register_net_hooks is called per-net, while nf_register_hook is NOT. So we need limit the calling of nf_register_hooks, and the same to it's pair: nf_unregister_hooks.