### PR TITLE
FIXME: building issue on OpenSUSE 42.1 (4.1.12.1)

### DIFF
--- a/driver/LKM/Makefile
+++ b/driver/LKM/Makefile
@@ -67,15 +67,20 @@ ccflags-y += -D SMITH_TRACE_EVENTS
 endif
 
 TRACE_SEQ_FILES := $(shell find -L $(K_I_PATH) -path \*/linux/trace_seq.h) /dev/null
-TRACE_SEQ_SEQ := $(shell sh -c "grep -sE struct[[:space:]]\+seq_buf[[:space:]]\+seq\; $(TRACE_SEQ_FILES)")
+TRACE_SEQ_SEQ := $(shell sh -c "grep -s trace_seq_used $(TRACE_SEQ_FILES)")
 ifneq ($(TRACE_SEQ_SEQ),)
 ccflags-y += -D SMITH_TRACE_SEQ
 endif
 
 PROCFS_H_FILES := $(shell find -L $(K_I_PATH) -path "*/linux/proc_fs.h") /dev/null
-PROCFS_PDE_DATA := $(shell sh -c "grep -s pde_data $(PROCFS_H_FILES)")
+PROCFS_PDE_DATA := $(shell sh -c "grep -s PDE_DATA $(PROCFS_H_FILES)")
 ifneq ($(PROCFS_PDE_DATA),)
 ccflags-y += -D SMITH_PROCFS_PDE_DATA
+else
+PROCFS_pde_data := $(shell sh -c "grep -s pde_data $(PROCFS_H_FILES)")
+ifneq ($(PROCFS_pde_data),)
+ccflags-y += -D SMITH_PROCFS_pde_data
+endif
 endif
 
 PROCNS_H_FILES := $(shell find -L $(K_I_PATH) -path "*/linux/proc_ns.h") /dev/null

--- a/driver/LKM/include/trace.h
+++ b/driver/LKM/include/trace.h
@@ -14,12 +14,7 @@
 #ifdef SMITH_TRACE_EVENTS
 #include <linux/trace_events.h>
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
-#define SMITH_TRACE_EVENTS
-#include <linux/trace_events.h>
-#else
 #include <linux/ftrace_event.h>
-#endif
 #endif
 
 #define RS "\x1e"
@@ -28,12 +23,7 @@
 #define SZ_128K				0x00020000
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
-#else
-#define PDE_DATA(i)  PDE(i)->data
-#endif
-
-#ifdef SMITH_TRACE_EVENTS
+#ifdef SMITH_TRACE_SEQ
 static inline int __trace_seq_used(struct trace_seq *s)
 {
 	return trace_seq_used(s);

--- a/driver/LKM/src/trace.c
+++ b/driver/LKM/src/trace.c
@@ -63,10 +63,10 @@ static int trace_open_pipe(struct inode *inode, struct file *filp)
     trace_seq_init(&iter->seq);
     mutex_init(&iter->mutex);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || defined(SMITH_PROCFS_PDE_DATA)
-    iter->ring = pde_data(inode);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if defined(SMITH_PROCFS_PDE_DATA)
     iter->ring = PDE_DATA(inode);
+#elif defined(SMITH_PROCFS_pde_data)
+    iter->ring = pde_data(inode);
 #else
     iter->ring = PDE(inode)->data;
 #endif


### PR DESCRIPTION
building issues for openSUSE 42.1 fixed: 
caused by backporting of trace_fs and trace_seq, now check header structures dynamically rather than using kernel versions
