### PR TITLE
Retrieve cURL information using the CurlHandle object since php8.0.

### DIFF
--- a/rasp/php/php/api.cpp
+++ b/rasp/php/php/api.cpp
@@ -201,6 +201,23 @@ std::string toString(
             return zero::strings::format("{%s}", zero::strings::join(items, ", ").c_str());
         }
 
+#if PHP_MAJOR_VERSION >= 8
+        case IS_OBJECT: {
+            const char *type = ZSTR_VAL(Z_OBJ_P(val)->ce->name);
+            if (!type)
+                break;
+
+            if (strcmp(type, "CurlHandle") == 0)
+                return curlInfo(
+                        val
+#if PHP_MAJOR_VERSION <= 5
+                        TSRMLS_CC
+#endif
+                );
+            return zero::strings::format("object(%s)", type);
+        }
+#endif
+
         case IS_RESOURCE: {
             const char *type = zend_rsrc_list_get_rsrc_type(
 #if PHP_MAJOR_VERSION > 5


### PR DESCRIPTION
Starting from PHP 8.0, the curl_init() function now returns a CurlHandle object instead of a resource.

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
