### PR TITLE
FIXME: building failure for CentOS 6

### DIFF
--- a/driver/LKM/src/smith_hook.c
+++ b/driver/LKM/src/smith_hook.c
@@ -14,7 +14,12 @@
 #include <linux/moduleparam.h>
 #include <linux/netfilter.h>
 #include <linux/netfilter_ipv4.h>
+
+#if IS_ENABLED(CONFIG_IPV6)
+#include <linux/ipv6.h>
+#include <net/ipv6.h> /* ipv6_addr_any */
 #include <linux/netfilter_ipv6.h>
+#endif
 
 #define EXIT_PROTECT 0
 #define SANDBOX 0

--- a/driver/LKM/src/trace_buffer.c
+++ b/driver/LKM/src/trace_buffer.c
@@ -26,6 +26,7 @@
 #include <linux/oom.h>
 #include <linux/kernel.h>
 
+#include "../include/util.h"
 #include "../include/trace_buffer.h"
 
 /* kernel has READ_ONCE defined since 3.18.13 */


### PR DESCRIPTION
1,  Network headers files rearranged and <net/ipv6.h> included:
    CentOS 6 got building failures due to lack of ipv6_addr_any
2,  IS_ENABLED() used by latest trace_ringbuffer, but not defined

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
