### PR TITLE
add windows crash_dump support & sys split

### DIFF
--- a/plugins/lib/rust/.gitignore
+++ b/plugins/lib/rust/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+dev.sh
+target/

--- a/plugins/lib/rust/Cargo.toml
+++ b/plugins/lib/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugins"
 version = "0.1.0"
 authors = ["zhanglei.sec <zhanglei.sec@bytedance.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -23,9 +23,24 @@ serde_json = "1"
 protobuf-codegen-pure = "2.3"
 
 [dependencies.windows]
-version = "0.48.0"
+version = "0.58.0"
 features = [
-    "Win32_System_Diagnostics_ToolHelp", 
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_Services",
+    "Win32_System_Kernel",
+    "Win32_System_JobObjects",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics",
+    "Win32_System_Diagnostics_ToolHelp", 
+    "Win32_System_Diagnostics_Debug_Extensions",
 ]
+
+
+# Library dependencies (Windows)
+[target.'cfg(target_os = "windows")'.dependencies]
+anyhow = "1.0"
+zip = "2.2"

--- a/plugins/lib/rust/src/lib.rs
+++ b/plugins/lib/rust/src/lib.rs
@@ -1,12 +1,3 @@
-pub mod bridge;
-pub mod logger;
-
-pub use bridge::*;
-use crossbeam::channel::{select, tick};
-use log::{debug, info};
-use parking_lot::Mutex;
-use protobuf::Message;
-use signal_hook::consts::SIGTERM;
 use std::{
     env,
     fs::File,
@@ -16,15 +7,17 @@ use std::{
     time::Duration,
 };
 
-#[cfg(target_family = "unix")]
-use signal_hook::{consts::SIGUSR1, iterator::Signals};
-#[cfg(target_family = "unix")]
-use std::os::unix::prelude::FromRawFd;
+use crossbeam::channel::{select, tick};
+use log::debug;
+use parking_lot::Mutex;
+use protobuf::Message;
 
-#[cfg(target_family = "windows")]
-use std::os::windows::prelude::{FromRawHandle, RawHandle};
-#[cfg(target_family = "windows")]
-use windows::Win32::System::Console::{GetStdHandle, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
+pub mod logger;
+
+pub mod bridge;
+pub use bridge::*;
+
+pub mod sys;
 
 #[derive(Clone)]
 pub enum EncodeType {
@@ -37,62 +30,26 @@ pub struct Client {
     writer: Arc<Mutex<BufWriter<File>>>,
     reader: Arc<Mutex<BufReader<File>>>,
 }
-#[cfg(feature = "debug")]
-const READ_PIPE_FD: i32 = 0;
-#[cfg(not(feature = "debug"))]
-const READ_PIPE_FD: i32 = 3;
-#[cfg(feature = "debug")]
-const WRITE_PIPE_FD: i32 = 1;
-#[cfg(not(feature = "debug"))]
-const WRITE_PIPE_FD: i32 = 4;
-const HIGH_PRIORIT_FD: i32 = 5;
 
 impl Client {
- 
     pub fn can_use_high() -> bool {
         match env::var("ELKEID_PLUGIN_HIGH_PRIORITY_PIPE") {
             Ok(value) => {
                 if !value.is_empty() {
                     return true;
                 }
-                
             }
             Err(_) => {
                 return false;
             }
-            
         }
         false
     }
     pub fn new(ignore_terminate: bool) -> Self {
-        
-        let writer = Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
-            #[cfg(target_family = "unix")]
-            {
-                File::from_raw_fd(WRITE_PIPE_FD)
-            }
-
-            #[cfg(target_family = "windows")]
-            {
-                let raw_handle = GetStdHandle(STD_OUTPUT_HANDLE).unwrap();
-                File::from_raw_handle(raw_handle.0 as _)
-            }
-        })));
+        let writer = sys::get_writer();
         let mut high_writer = writer.clone();
-        if  Self::can_use_high() {
-            high_writer = Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
-                #[cfg(target_family = "unix")]
-                {
-                     File::from_raw_fd(HIGH_PRIORIT_FD)
-                }
-    
-                #[cfg(target_family = "windows")]
-                {
-                    let raw_handle = GetStdHandle(STD_OUTPUT_HANDLE).unwrap();
-                    File::from_raw_handle(raw_handle.0 as _)
-                }
-            })));
-
+        if Self::can_use_high() {
+            high_writer = sys::get_high_writer();
             let high_writer_c = high_writer.clone();
             thread::spawn(move || {
                 let ticker = tick(Duration::from_millis(200));
@@ -109,19 +66,8 @@ impl Client {
             });
         }
 
-        let reader = Arc::new(Mutex::new(BufReader::new(unsafe {
-            #[cfg(target_family = "unix")]
-            {
-                File::from_raw_fd(READ_PIPE_FD)
-            }
+        let reader = sys::get_reader();
 
-            #[cfg(target_family = "windows")]
-            {
-                let raw_handle = GetStdHandle(STD_INPUT_HANDLE).unwrap();
-                File::from_raw_handle(raw_handle.0 as _)
-            }
-        })));
-        
         let writer_c = writer.clone();
         thread::spawn(move || {
             let ticker = tick(Duration::from_millis(200));
@@ -136,26 +82,18 @@ impl Client {
                 }
             }
         });
-        #[cfg(target_family = "unix")]
+
+        sys::regist_exception_handler();
+
         if ignore_terminate {
-            let mut signals = Signals::new(&[SIGTERM, SIGUSR1]).unwrap();
-            thread::spawn(move || {
-                for sig in signals.forever() {
-                    if sig == SIGTERM {
-                        info!("received signal: {:?}, wait 3 secs to exit", sig);
-                        thread::sleep(Duration::from_secs(3));
-                        unsafe {
-                            if  Self::can_use_high() {
-                                libc::close(HIGH_PRIORIT_FD);
-                            }
-                            libc::close(WRITE_PIPE_FD);
-                            libc::close(READ_PIPE_FD);
-                        }
-                    }
-                }
-            });
+            sys::ignore_terminate()
         }
-        Self { high_writer, writer, reader }
+
+        Self {
+            high_writer,
+            writer,
+            reader,
+        }
     }
     pub fn send_record(&mut self, rec: &Record) -> Result<(), Error> {
         let mut w = self.writer.lock();
@@ -176,7 +114,6 @@ impl Client {
         }
     }
     pub fn send_record_high_priority(&mut self, rec: &Record) -> Result<(), Error> {
-
         let mut w = self.high_writer.lock();
         #[cfg(not(feature = "debug"))]
         {
@@ -209,7 +146,6 @@ impl Client {
         }
         #[cfg(feature = "debug")]
         {
-            
             for rec in recs.iter() {
                 w.write_all(b"{\"data_type\":")?;
                 w.write_all(rec.data_type.to_string().as_bytes())?;
@@ -220,7 +156,7 @@ impl Client {
                 w.write_all(b"}\n")
             }
             Ok(())
-       }
+        }
     }
 
     pub fn send_records(&mut self, recs: &Vec<Record>) -> Result<(), Error> {

--- a/plugins/lib/rust/src/sys/mod.rs
+++ b/plugins/lib/rust/src/sys/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_family = "windows")]
+pub mod windows;
+#[cfg(target_family = "windows")]
+pub use windows::*;
+
+#[cfg(target_family = "unix")]
+pub mod unix;
+#[cfg(target_family = "unix")]
+pub use unix::*;

--- a/plugins/lib/rust/src/sys/unix.rs
+++ b/plugins/lib/rust/src/sys/unix.rs
@@ -26,7 +26,7 @@ pub fn get_writer() -> Arc<Mutex<BufWriter<File>>> {
 
 pub fn get_high_writer() -> Arc<Mutex<BufWriter<File>>> {
     Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
-        File::from_raw_fd(WRITE_PIPE_FD)
+        File::from_raw_fd(HIGH_PRIORIT_FD)
     })))
 }
 
@@ -37,7 +37,7 @@ pub fn get_reader() -> Arc<Mutex<BufReader<File>>> {
 }
 
 extern "C" fn signal_handler(signal: i32) {
-    eprintln!("catched signal {:?}, exit", signal);
+    eprintln!("catched signal {:?}, wait 3 seconds and exit", signal);
     unsafe {
         libc::sleep(3);
         libc::close(WRITE_PIPE_FD);

--- a/plugins/lib/rust/src/sys/unix.rs
+++ b/plugins/lib/rust/src/sys/unix.rs
@@ -1,0 +1,61 @@
+use std::os::unix::prelude::FromRawFd;
+
+#[cfg(feature = "debug")]
+const READ_PIPE_FD: i32 = 0;
+#[cfg(not(feature = "debug"))]
+const READ_PIPE_FD: i32 = 3;
+#[cfg(feature = "debug")]
+const WRITE_PIPE_FD: i32 = 1;
+#[cfg(not(feature = "debug"))]
+const WRITE_PIPE_FD: i32 = 4;
+const HIGH_PRIORIT_FD: i32 = 5;
+
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    sync::Arc,
+};
+
+use parking_lot::Mutex;
+
+pub fn get_writer() -> Arc<Mutex<BufWriter<File>>> {
+    Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
+        File::from_raw_fd(WRITE_PIPE_FD)
+    })))
+}
+
+pub fn get_high_writer() -> Arc<Mutex<BufWriter<File>>> {
+    Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
+        File::from_raw_fd(WRITE_PIPE_FD)
+    })))
+}
+
+pub fn get_reader() -> Arc<Mutex<BufReader<File>>> {
+    Arc::new(Mutex::new(BufReader::with_capacity(512 * 1024, unsafe {
+        File::from_raw_fd(READ_PIPE_FD)
+    })))
+}
+
+extern "C" fn signal_handler(signal: i32) {
+    eprintln!("catched signal {:?}, exit", signal);
+    unsafe {
+        libc::sleep(3);
+        libc::close(WRITE_PIPE_FD);
+        libc::close(READ_PIPE_FD);
+        if libc::fcntl(HIGH_PRIORIT_FD, libc::F_GETFD) != -1
+            || std::io::Error::last_os_error().kind() != std::io::ErrorKind::InvalidInput
+        {
+            libc::close(READ_PIPE_FD);
+        }
+    }
+}
+
+pub fn ignore_terminate() {
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_IGN);
+        libc::signal(libc::SIGUSR1, libc::SIG_IGN);
+        libc::signal(libc::SIGTERM, signal_handler as _);
+    }
+}
+
+pub fn regist_exception_handler() {}

--- a/plugins/lib/rust/src/sys/windows.rs
+++ b/plugins/lib/rust/src/sys/windows.rs
@@ -1,0 +1,157 @@
+use std::{
+    env,
+    fs::File,
+    io::{BufReader, BufWriter, Error, Read, Write},
+    os::windows::{
+        io::AsRawHandle,
+        prelude::{FromRawHandle, RawHandle},
+        raw::HANDLE,
+    },
+    sync::Arc,
+    thread,
+    time::Duration,
+};
+
+use anyhow::Result;
+use libc::{signal, SIGABRT, SIGINT, SIGSEGV, SIG_IGN};
+use parking_lot::Mutex;
+use zip;
+
+use windows::Win32::{
+    Foundation::FALSE,
+    System::{
+        Console::{GetStdHandle, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE},
+        Diagnostics::Debug::{
+            MiniDumpNormal, MiniDumpWithFullMemory, MiniDumpWithHandleData,
+            MiniDumpWithIndirectlyReferencedMemory, MiniDumpWithThreadInfo, MiniDumpWriteDump,
+            SetUnhandledExceptionFilter, EXCEPTION_EXECUTE_HANDLER, EXCEPTION_POINTERS,
+            MINIDUMP_EXCEPTION_INFORMATION,
+        },
+        Threading::{ExitProcess, GetCurrentProcess, GetCurrentProcessId, GetCurrentThreadId},
+    },
+};
+
+pub fn get_writer() -> Arc<Mutex<BufWriter<File>>> {
+    Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
+        let raw_handle = GetStdHandle(STD_OUTPUT_HANDLE).unwrap();
+        File::from_raw_handle(raw_handle.0 as _)
+    })))
+}
+
+pub fn get_high_writer() -> Arc<Mutex<BufWriter<File>>> {
+    Arc::new(Mutex::new(BufWriter::with_capacity(512 * 1024, unsafe {
+        let raw_handle = GetStdHandle(STD_OUTPUT_HANDLE).unwrap();
+        File::from_raw_handle(raw_handle.0 as _)
+    })))
+}
+
+pub fn get_reader() -> Arc<Mutex<BufReader<File>>> {
+    Arc::new(Mutex::new(BufReader::with_capacity(512 * 1024, unsafe {
+        let raw_handle = GetStdHandle(STD_INPUT_HANDLE).unwrap();
+        File::from_raw_handle(raw_handle.0 as _)
+    })))
+}
+
+fn guess_crash_dump_name() -> String {
+    match env::current_exe() {
+        Ok(path) => {
+            if let Some(file_name) = path.file_name() {
+                if let Some(name_str) = file_name.to_str() {
+                    return format!("{}", name_str.replace(".exe", ".dmp"));
+                } else {
+                    return "crash_dump.dmp".to_string();
+                }
+            } else {
+                return "crash_dump.dmp".to_string();
+            }
+        }
+        Err(e) => {
+            return "crash_dump.dmp".to_string();
+        }
+    }
+}
+
+fn create_dump(exception_info: *const EXCEPTION_POINTERS, dump_path: &str) -> Result<()> {
+    unsafe {
+        let dump_file = File::create(dump_path)?;
+        let dump_file_handle = dump_file.as_raw_handle() as HANDLE;
+
+        let mut dump_info: MINIDUMP_EXCEPTION_INFORMATION = std::mem::zeroed();
+        dump_info.ThreadId = GetCurrentThreadId();
+        dump_info.ExceptionPointers = exception_info as _;
+        dump_info.ClientPointers = FALSE;
+
+        MiniDumpWriteDump(
+            GetCurrentProcess(),
+            GetCurrentProcessId(),
+            windows::Win32::Foundation::HANDLE(dump_file_handle),
+            MiniDumpNormal
+                | MiniDumpWithThreadInfo
+                | MiniDumpWithHandleData
+                | MiniDumpWithIndirectlyReferencedMemory
+                | MiniDumpWithFullMemory,
+            Some(&dump_info),
+            None,
+            None,
+        )?;
+    }
+    return Ok(());
+}
+
+extern "system" fn exception_handler(exception_info: *const EXCEPTION_POINTERS) -> i32 {
+    let dump_path = guess_crash_dump_name();
+    let dumpzip_path = dump_path.replace("dmp", "zip");
+
+    unsafe {
+        eprintln!("Exception occurred! Generating dump...");
+        if let Err(e) = create_dump(exception_info, &dump_path) {
+            eprintln!("Failed to generate crash_dump :{}.", e);
+        }
+        eprintln!("crash_dump.dmp Generated.");
+        if let Err(e) = zip_minidump(&dump_path, &dumpzip_path) {
+            eprintln!("Failed to zip crash_dump :{}.", e);
+        } else {
+            let _ = std::fs::remove_file(dump_path);
+        }
+    }
+    EXCEPTION_EXECUTE_HANDLER
+}
+
+extern "C" fn signal_handler(signal: i32) {
+    eprintln!("catched signal {}", signal);
+    unsafe {
+        ExitProcess(0);
+    }
+}
+
+fn zip_minidump(dump_path: &str, zip_path: &str) -> Result<()> {
+    let dump_file = File::open(dump_path)?;
+    let zip_file = File::create(zip_path)?;
+    let mut zip_writer = zip::ZipWriter::new(zip_file);
+
+    // 设置压缩选项
+    zip_writer.start_file(
+        dump_path,
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Bzip2),
+    )?;
+
+    // 将 Minidump 内容写入 ZIP
+    std::io::copy(&mut &dump_file, &mut zip_writer)?;
+    zip_writer.finish()?;
+
+    Ok(())
+}
+
+pub fn regist_exception_handler() {
+    unsafe {
+        SetUnhandledExceptionFilter(Some(exception_handler));
+        //signal(SIGABRT, signal_handler as _);
+        //signal(SIGSEGV, signal_handler as _);
+    }
+}
+
+pub fn ignore_terminate() {
+    unsafe {
+        signal(SIGINT, SIG_IGN); // Ingore nssm restart agent
+    }
+}


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] update cargo edition into 2021 (rust 1.82.0)
* [x] split sys utils into unix and windows
* [x] windows plugin exit code 0xc000013a after recived SIGINT while user execute ```nssm.exe restart agent``` (only on exit error code, no affect on running stage)
* [x] regist exception handler with crash dump for windows
