### PR TITLE
opt: update plugins lib

### DIFF
--- a/plugins/lib/rust/Cargo.toml
+++ b/plugins/lib/rust/Cargo.toml
@@ -15,7 +15,7 @@ crossbeam = "0.8"
 lazy_static = "1.4"
 protobuf = "2"
 parking_lot = "0.11"
-signal-hook = "0.3.14"
+signal-hook = "0.3"
 libc = "0.2"
 serde_json = "1"
 
@@ -43,4 +43,4 @@ features = [
 # Library dependencies (Windows)
 [target.'cfg(target_os = "windows")'.dependencies]
 anyhow = "1.0"
-zip = "2.2"
+zip = "2"


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] zip.rs 2.2 has been removed, change plugins/lib/rust zip into 2
