### PR TITLE
FIXME: dkms failed to build when installing new kernel

### DIFF
--- a/driver/LKM/Makefile
+++ b/driver/LKM/Makefile
@@ -1,5 +1,5 @@
 MODULE_NAME		:= hids_driver
-KERNEL_HEAD		:= $(if $(KVERSION),$(KVERSION),$(shell uname -r))
+KERNEL_HEAD		:= $(if $(wildcard $(srctree)/include/.),_-_,$(if $(KVERSION),$(KVERSION),$(shell uname -r)))
 
 $(MODULE_NAME)-objs	:= src/init.o src/trace.o src/trace_buffer.o src/smith_hook.o \
                            src/anti_rootkit.o src/filter.o src/util.o src/memcache.o


### PR DESCRIPTION
'uname -r' used in Makefile scripts to locate header files, then wrong compiler switches generated from old headers are to be used for the new kernel
