### PR TITLE
fix(agent): propagate file upload read errors

### DIFF
--- a/agent/transport/file_ext.go
+++ b/agent/transport/file_ext.go
@@ -99,9 +99,9 @@ func handleUpload(ctx context.Context, wg *sync.WaitGroup, req UploadRequest) {
 	for {
 		select {
 		case <-ticker.C:
-			n, rerr := io.ReadFull(file, buf)
-			if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-				zap.S().Error(err)
+			n, done, rerr := readUploadChunk(file, buf)
+			if rerr != nil {
+				zap.S().Error(rerr)
 				return
 			}
 			err = client.Send(
@@ -116,7 +116,7 @@ func handleUpload(ctx context.Context, wg *sync.WaitGroup, req UploadRequest) {
 			}
 			size += n
 			zap.S().Infof("upload process:%v/%v", size, expectedSize)
-			if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+			if done {
 				var resp *proto.FileUploadResponse
 				resp, err = client.CloseAndRecv()
 				if err != nil {
@@ -129,5 +129,17 @@ func handleUpload(ctx context.Context, wg *sync.WaitGroup, req UploadRequest) {
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func readUploadChunk(reader io.Reader, buf []byte) (n int, done bool, err error) {
+	n, err = io.ReadFull(reader, buf)
+	switch err {
+	case nil:
+		return n, false, nil
+	case io.EOF, io.ErrUnexpectedEOF:
+		return n, true, nil
+	default:
+		return n, false, err
 	}
 }

--- a/agent/transport/file_ext_test.go
+++ b/agent/transport/file_ext_test.go
@@ -1,0 +1,53 @@
+package transport
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestReadUploadChunk(t *testing.T) {
+	tests := []struct {
+		name     string
+		reader   *strings.Reader
+		bufSize  int
+		wantN    int
+		wantDone bool
+	}{
+		{name: "full chunk", reader: strings.NewReader("data"), bufSize: 4, wantN: 4},
+		{name: "final partial chunk", reader: strings.NewReader("data"), bufSize: 8, wantN: 4, wantDone: true},
+		{name: "empty file", reader: strings.NewReader(""), bufSize: 8, wantDone: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, tt.bufSize)
+			n, done, err := readUploadChunk(tt.reader, buf)
+			if err != nil {
+				t.Fatalf("readUploadChunk() error = %v", err)
+			}
+			if n != tt.wantN || done != tt.wantDone {
+				t.Fatalf("readUploadChunk() = (%d, %t), want (%d, %t)", n, done, tt.wantN, tt.wantDone)
+			}
+		})
+	}
+}
+
+func TestReadUploadChunkPropagatesReadError(t *testing.T) {
+	wantErr := errors.New("disk read failed")
+	n, done, err := readUploadChunk(failingReader{err: wantErr}, make([]byte, 8))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("readUploadChunk() error = %v, want %v", err, wantErr)
+	}
+	if n != 0 || done {
+		t.Fatalf("readUploadChunk() = (%d, %t), want (0, false)", n, done)
+	}
+}


### PR DESCRIPTION
## Summary

- propagate non-EOF errors returned by `io.ReadFull` during file uploads
- preserve the existing EOF and final-partial-chunk behavior
- add focused tests for full, partial, empty, and failed reads

## Problem

The upload loop stores the result of `io.ReadFull` in `rerr`, but checks the unrelated outer `err` variable. A disk or network-filesystem read error is therefore ignored, and the loop may send an incomplete chunk as if the read succeeded.

The helper introduced here classifies successful/full reads, normal completion (`io.EOF` and `io.ErrUnexpectedEOF`), and actual read failures explicitly. The caller returns before `client.Send` when a real read failure occurs.

## Validation

- `go test ./transport/file_ext.go ./transport/file_ext_test.go`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/elkeid-transport.test ./transport`
- `GOOS=linux GOARCH=amd64 go vet ./transport`
- `go vet ./transport/file_ext.go ./transport/file_ext_test.go`

The package-wide test executable is cross-compiled because the agent only provides `plugin.Load` and `Plugin.Shutdown` implementations for Linux.

Fixes #748